### PR TITLE
Update to Ink 6.1.1

### DIFF
--- a/src/pink/attribute.gleam
+++ b/src/pink/attribute.gleam
@@ -61,6 +61,7 @@ pub type JustifyContent {
   ContentEnd
   ContentSpaceBetween
   ContentSpaceAround
+  ContentSpaceEvenly
 }
 
 /// `Display` is the type the function `display` accepts
@@ -615,6 +616,13 @@ pub fn align_self(align: AlignSelf) -> Attribute {
 /// ])
 /// // -> "  X   Y  "
 /// ```
+/// ```gleam
+/// box([justify_content(ContentSpaceEvenly)], [
+///   text([], "X"),
+///   text([], "Y")
+/// ])
+/// // -> "   X   Y   "
+/// ```
 pub fn justify_content(justify: JustifyContent) -> Attribute {
   Attribute(
     "justifyContent",
@@ -624,6 +632,7 @@ pub fn justify_content(justify: JustifyContent) -> Attribute {
       ContentEnd -> "flex-end"
       ContentSpaceBetween -> "space-between"
       ContentSpaceAround -> "space-around"
+      ContentSpaceEvenly -> "space-evenly"
     }),
   )
 }


### PR DESCRIPTION
Other than some bugs fix and internal/dependency update, Ink only have this DX change:

- Support `space-evenly` value for `justifyContent` attribute. (This PR added this)
- Add `backgroundColor` support to `Box` component. (Pink already support this)

So I made this small PR just to quickly update Pink and I hope this work. Thanks.